### PR TITLE
Update deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,27 +45,37 @@
       "integrity": "sha512-Lbv9WwWKsWydCc4iC3n11RmKXC7eIwdo3lEB5Em4qFAMkC69ZHWmuv4YvQjbubRGuyAlgGI2Gvu0NvCld7BJ0A=="
     },
     "@ledgerhq/devices": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-5.22.0.tgz",
-      "integrity": "sha512-oJxhee/zlHmIx66zvQQTSpIsHOiiLjALemTX9oUtB4xQwFvoiptPnBCeTDTM9teode7wzk7oE9qdUAZuat+nCg==",
+      "version": "5.23.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-5.23.0.tgz",
+      "integrity": "sha512-XR9qTwn14WwN8VSMsYD9NTX/TgkmrTnXEh0pIj6HMRZwFzBPzslExOcXuCm3V9ssgAEAxv3VevfV8UulvvZUXA==",
       "requires": {
-        "@ledgerhq/errors": "^5.22.0",
-        "@ledgerhq/logs": "^5.22.0",
-        "rxjs": "^6.6.2"
+        "@ledgerhq/errors": "^5.23.0",
+        "@ledgerhq/logs": "^5.23.0",
+        "rxjs": "^6.6.3"
+      },
+      "dependencies": {
+        "rxjs": {
+          "version": "6.6.3",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
+          "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        }
       }
     },
     "@ledgerhq/errors": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-5.22.0.tgz",
-      "integrity": "sha512-XDT0meBn39+q+JWzUFXmiFbVYLTy+uHRFMb9napcxyZ0Q/MdKkle9/vkgtvRHjPIkGobklXpyefsgH3BZQHukA=="
+      "version": "5.23.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-5.23.0.tgz",
+      "integrity": "sha512-qtpX8aFrUUlYfOMu7BxTvxqUa8CniE+tEBpVEjYUhVbFdVJjM4ouwJD++RtQkMAU2c5jE7xb12WnUnf5BlAgLQ=="
     },
     "@ledgerhq/hw-transport": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-5.22.0.tgz",
-      "integrity": "sha512-MFfkVGYMYnr6fI4XGnJQNLd36JIrRpvd5WBmVSDhCO3UKUER2fJ9koVBGc97o7yXtE5IAlJKF+nR9HZJIa0lRQ==",
+      "version": "5.23.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-5.23.0.tgz",
+      "integrity": "sha512-ICTG3Bst62SkC+lYYFgpKk5G4bAOxeIvptXnTLOhf6VqeN7gdHfiRzZwNPnKzI2pxmcEVbBitgsxEIEQJmDKVA==",
       "requires": {
-        "@ledgerhq/devices": "^5.22.0",
-        "@ledgerhq/errors": "^5.22.0",
+        "@ledgerhq/devices": "^5.23.0",
+        "@ledgerhq/errors": "^5.23.0",
         "events": "^3.2.0"
       },
       "dependencies": {
@@ -77,36 +87,43 @@
       }
     },
     "@ledgerhq/hw-transport-node-hid": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-node-hid/-/hw-transport-node-hid-5.22.0.tgz",
-      "integrity": "sha512-TrSQEGiYXBW8FQS2QEAmk/g+vwcKQ2MZVjPiIaqSCGnwVgmKOXfMetPjwgwr8k6XiQ7YMRdpsXa0GpIvTowqRA==",
+      "version": "5.23.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-node-hid/-/hw-transport-node-hid-5.23.0.tgz",
+      "integrity": "sha512-9mNc66S0s0C1Q5s2Vs8dhfHk5SRHvNVF2OsvXv8ir5r2O2ew4FOclZONJaVdFLrHLtoaFmtt8Az1e2NO6Xc8RA==",
       "requires": {
-        "@ledgerhq/devices": "^5.22.0",
-        "@ledgerhq/errors": "^5.22.0",
-        "@ledgerhq/hw-transport": "^5.22.0",
-        "@ledgerhq/hw-transport-node-hid-noevents": "^5.22.0",
-        "@ledgerhq/logs": "^5.22.0",
-        "lodash": "^4.17.19",
+        "@ledgerhq/devices": "^5.23.0",
+        "@ledgerhq/errors": "^5.23.0",
+        "@ledgerhq/hw-transport": "^5.23.0",
+        "@ledgerhq/hw-transport-node-hid-noevents": "^5.23.0",
+        "@ledgerhq/logs": "^5.23.0",
+        "lodash": "^4.17.20",
         "node-hid": "^1.3.0",
         "usb": "^1.6.3"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+        }
       }
     },
     "@ledgerhq/hw-transport-node-hid-noevents": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-node-hid-noevents/-/hw-transport-node-hid-noevents-5.22.0.tgz",
-      "integrity": "sha512-6sxrqTcBEGvhVDOS5Vy3mKZgaVOKbHplxm4o/3PmtugJcvpEBvDNGXNh3PMWPtHXXYQ5E5C/qWh7Y+gYshMmTg==",
+      "version": "5.23.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-node-hid-noevents/-/hw-transport-node-hid-noevents-5.23.0.tgz",
+      "integrity": "sha512-tJQRAosKxWu33U28Pu3XmrktafhA3Vdx83Jdw260NVpqWs6ImA7j0A6242FQzYFEi92II/02jsrW6OBZo8bNUA==",
       "requires": {
-        "@ledgerhq/devices": "^5.22.0",
-        "@ledgerhq/errors": "^5.22.0",
-        "@ledgerhq/hw-transport": "^5.22.0",
-        "@ledgerhq/logs": "^5.22.0",
+        "@ledgerhq/devices": "^5.23.0",
+        "@ledgerhq/errors": "^5.23.0",
+        "@ledgerhq/hw-transport": "^5.23.0",
+        "@ledgerhq/logs": "^5.23.0",
         "node-hid": "^1.3.0"
       }
     },
     "@ledgerhq/logs": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-5.22.0.tgz",
-      "integrity": "sha512-jV4mJxD1aieORm+sK9bYakQd9GMLd7KAxgt2IaxhrTU+QD5Ne47mxQOTys9p7f5w25ujs3R+Px2t3KiMRASHtg=="
+      "version": "5.23.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-5.23.0.tgz",
+      "integrity": "sha512-88M8RkVHl44k6MAhfrYhx25opnJV24/2XpuTUVklID11f9rBdE+6RZ9OMs39dyX2sDv7TuzIPi5nTRoCqZMDYw=="
     },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
@@ -541,9 +558,9 @@
       }
     },
     "@tacoinfra/harbinger-lib": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@tacoinfra/harbinger-lib/-/harbinger-lib-1.4.0.tgz",
-      "integrity": "sha512-gbi3FgEpr5sxyX5Un3+uqXpnddHmpS3joTDko4QL8uAHoofylqrhcgoddhx08EBQA0NCKDajzo1FlftDWGzgbg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@tacoinfra/harbinger-lib/-/harbinger-lib-1.5.0.tgz",
+      "integrity": "sha512-piNJUnnvcqLMYbr2Tjl53gK7vUMC1pRYqRcy9ULIIv/zzItIPsSv+pWtibZTOIxXDCWCHbhX58qwuk1kEpZelQ==",
       "requires": {
         "@lapo/asn1js": "1.1.0",
         "@ledgerhq/hw-transport": "^5.15.0",
@@ -569,9 +586,9 @@
       },
       "dependencies": {
         "aws-sdk": {
-          "version": "2.739.0",
-          "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.739.0.tgz",
-          "integrity": "sha512-N2XyxY12gs0GJc26O8TmdT30ovEKWsPX787CNW24g0cXTCyc/Teltq0re6yGxfaH0VmN6qONNLr3E59JtJ3neA==",
+          "version": "2.748.0",
+          "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.748.0.tgz",
+          "integrity": "sha512-H+DCioQ4AChoBxGMtagcJ3a0mM0lOh3ta/dWIrfPTECAlRIuxlrBDp78cRhPgvdYYUxW54kB/IaHGR2xPP8JXw==",
           "requires": {
             "buffer": "4.9.2",
             "events": "1.1.1",
@@ -1712,9 +1729,9 @@
       }
     },
     "bl": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
-      "integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
+      "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
       "requires": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -5935,9 +5952,9 @@
       }
     },
     "loglevel": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.8.tgz",
-      "integrity": "sha512-bsU7+gc9AJ2SqpzxwU3+1fedl8zAntbtC5XYlt3s2j1hJcn2PsXSmgN8TaLG/J1/2mod4+cE/3vNL70/c1RNCA=="
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.7.0.tgz",
+      "integrity": "sha512-i2sY04nal5jDcagM3FMfG++T69GEEM8CYuOfeOIvmXzOIcwE9a/CJPR0MFM97pYMj/u10lzz7/zd7+qwhrBTqQ=="
     },
     "long": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "Blockscale LLC",
   "license": "MIT",
   "dependencies": {
-    "@tacoinfra/harbinger-lib": "1.4.0",
+    "@tacoinfra/harbinger-lib": "^1.5.0",
     "@types/aws-lambda": "^8.10.51",
     "@types/aws-sdk": "^2.7.0",
     "@types/secp256k1": "^4.0.1",


### PR DESCRIPTION
Pulls in `harbinger-lib` 1.5.0 and updates other deps with `npm audit fix`.