### PR TITLE
Allow Updates to be sent with Zero-Fees

### DIFF
--- a/handler.ts
+++ b/handler.ts
@@ -20,6 +20,7 @@ export const updateOracle: APIGatewayProxyHandler = async (
       ? process.env.NORMALIZER_CONTRACT_ADDRESS
       : undefined
   const signerUrl = process.env.SIGNER_URL
+  const enableZeroFees = process.env.ENABLE_ZERO_FEES === 'TRUE'
 
   if (
     awsKmsKeyId === undefined ||
@@ -52,6 +53,7 @@ export const updateOracle: APIGatewayProxyHandler = async (
       coinbaseApiKeyPassphrase,
       assets,
       normalizerContractAddress,
+      enableZeroFees
     )
     return {
       statusCode: 200,

--- a/package-lock.json
+++ b/package-lock.json
@@ -496,11 +496,11 @@
       }
     },
     "@tacoinfra/conseil-kms": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@tacoinfra/conseil-kms/-/conseil-kms-1.0.0.tgz",
-      "integrity": "sha512-Tth6/Yr6iwDKCQ1N2stBPWsfBeXrOatlWrpMq5Bj7jqseAut8TMI7MneUvYyr6mI4U+zuSipmmHx9ROXCdy2vA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@tacoinfra/conseil-kms/-/conseil-kms-1.1.0.tgz",
+      "integrity": "sha512-YLaBin88oPAm/DdV9DGdHysc5vYFbVs3o/8bqiw8xWWykJnt52AtfGftVVSXybG3T+ozGuLe9xOquUsm7Fud2A==",
       "requires": {
-        "@tacoinfra/tezos-kms": "^1.0.0",
+        "@tacoinfra/tezos-kms": "^1.1.0",
         "@types/node": "^14.10.1",
         "conseiljs": "^5.0.4"
       },
@@ -526,14 +526,14 @@
       }
     },
     "@tacoinfra/harbinger-lib": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@tacoinfra/harbinger-lib/-/harbinger-lib-1.7.0.tgz",
-      "integrity": "sha512-KENc3NY2bO3Ix63mrb5WMgKu45DI+0KdtsLrz2aJMfzAORHVy+C+QqfpVJs/cgj3Fecv4iqGm+V7xJkHH1omDA==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@tacoinfra/harbinger-lib/-/harbinger-lib-1.7.1.tgz",
+      "integrity": "sha512-GaoQuIixP08QALQZ4QvkluWWjrzmyJkPc60BiOxvY6JEqo9OWKugC5WqdH5BsM+OlHasR6zFPC91hiwlv99Qvw==",
       "requires": {
         "@lapo/asn1js": "1.1.0",
         "@ledgerhq/hw-transport": "^5.15.0",
         "@ledgerhq/hw-transport-node-hid": "^5.16.0",
-        "@tacoinfra/conseil-kms": "^1.0.0",
+        "@tacoinfra/conseil-kms": "^1.1.0",
         "@types/libsodium-wrappers": "^0.7.7",
         "@types/node": "^14.0.6",
         "@types/node-fetch": "^2.5.7",
@@ -609,9 +609,9 @@
       }
     },
     "@tacoinfra/tezos-kms": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@tacoinfra/tezos-kms/-/tezos-kms-1.0.0.tgz",
-      "integrity": "sha512-ZCLJOLlMHLP4exqIzJY+l9KTdEyxJoGyrayFfLxwswIB+GTy+xYx/VksNUlbxXNMnTR14wpkRauXxVvdYX3ITw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@tacoinfra/tezos-kms/-/tezos-kms-1.1.0.tgz",
+      "integrity": "sha512-dyPOum4GcZKnJYj2MYQV/xmo2dFWqFKWS+n0ERJ7SSOOXHo6U/0sKb+7BXnuRrZQZDMOwSAj+8Ju2WEJshsy3w==",
       "requires": {
         "@types/node": "^14.10.1",
         "@types/secp256k1": "^4.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,12 +45,12 @@
       "integrity": "sha512-Lbv9WwWKsWydCc4iC3n11RmKXC7eIwdo3lEB5Em4qFAMkC69ZHWmuv4YvQjbubRGuyAlgGI2Gvu0NvCld7BJ0A=="
     },
     "@ledgerhq/devices": {
-      "version": "5.23.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-5.23.0.tgz",
-      "integrity": "sha512-XR9qTwn14WwN8VSMsYD9NTX/TgkmrTnXEh0pIj6HMRZwFzBPzslExOcXuCm3V9ssgAEAxv3VevfV8UulvvZUXA==",
+      "version": "5.28.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-5.28.0.tgz",
+      "integrity": "sha512-Tkygc1nfioxfv4YWF5VGHito3ZHQAiNM7YV+Kqr3n/gz4meT5f9DfvqvikTF5XxX+mXpCMc4IlzwbUAoeNOHiQ==",
       "requires": {
-        "@ledgerhq/errors": "^5.23.0",
-        "@ledgerhq/logs": "^5.23.0",
+        "@ledgerhq/errors": "^5.28.0",
+        "@ledgerhq/logs": "^5.28.0",
         "rxjs": "^6.6.3"
       },
       "dependencies": {
@@ -65,17 +65,17 @@
       }
     },
     "@ledgerhq/errors": {
-      "version": "5.23.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-5.23.0.tgz",
-      "integrity": "sha512-qtpX8aFrUUlYfOMu7BxTvxqUa8CniE+tEBpVEjYUhVbFdVJjM4ouwJD++RtQkMAU2c5jE7xb12WnUnf5BlAgLQ=="
+      "version": "5.28.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-5.28.0.tgz",
+      "integrity": "sha512-dNBVriJbdiTerT7I102sAMBxuJqmuMCQSfIdQ+3euvb+2Fx7UPM/w9RHZ0HZGsz/SdeBblWAH0aIQmtDX/vW9g=="
     },
     "@ledgerhq/hw-transport": {
-      "version": "5.23.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-5.23.0.tgz",
-      "integrity": "sha512-ICTG3Bst62SkC+lYYFgpKk5G4bAOxeIvptXnTLOhf6VqeN7gdHfiRzZwNPnKzI2pxmcEVbBitgsxEIEQJmDKVA==",
+      "version": "5.28.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-5.28.0.tgz",
+      "integrity": "sha512-dQm45axzWSJhiaDB2csBCFPH/PGjE8kB+3uSeoUJ752FqgndZgrN9UKOPPxcmaf69jnQeTZAFEWc8g63yMPYOg==",
       "requires": {
-        "@ledgerhq/devices": "^5.23.0",
-        "@ledgerhq/errors": "^5.23.0",
+        "@ledgerhq/devices": "^5.28.0",
+        "@ledgerhq/errors": "^5.28.0",
         "events": "^3.2.0"
       },
       "dependencies": {
@@ -87,15 +87,15 @@
       }
     },
     "@ledgerhq/hw-transport-node-hid": {
-      "version": "5.23.2",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-node-hid/-/hw-transport-node-hid-5.23.2.tgz",
-      "integrity": "sha512-u0oBoKFltMk05T5ySnemLKoUtUXmB25196PuDe8C+vdA34usoESiNZb49Ookp1vAw7BHzImZYo1moF+IlLGVZQ==",
+      "version": "5.28.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-node-hid/-/hw-transport-node-hid-5.28.0.tgz",
+      "integrity": "sha512-ZCOsJs4PL4ndXiyZY++W8als10ARfObE20N92j+/ikvwU5bHjbSFOnoRK23xNj9NawO7aCm0F8ftCrZfYOSq/Q==",
       "requires": {
-        "@ledgerhq/devices": "^5.23.0",
-        "@ledgerhq/errors": "^5.23.0",
-        "@ledgerhq/hw-transport": "^5.23.0",
-        "@ledgerhq/hw-transport-node-hid-noevents": "^5.23.2",
-        "@ledgerhq/logs": "^5.23.0",
+        "@ledgerhq/devices": "^5.28.0",
+        "@ledgerhq/errors": "^5.28.0",
+        "@ledgerhq/hw-transport": "^5.28.0",
+        "@ledgerhq/hw-transport-node-hid-noevents": "^5.28.0",
+        "@ledgerhq/logs": "^5.28.0",
         "lodash": "^4.17.20",
         "node-hid": "1.3.0",
         "usb": "^1.6.3"
@@ -109,21 +109,21 @@
       }
     },
     "@ledgerhq/hw-transport-node-hid-noevents": {
-      "version": "5.23.2",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-node-hid-noevents/-/hw-transport-node-hid-noevents-5.23.2.tgz",
-      "integrity": "sha512-8LiF87iIZWJaXMptXJ64ZnMb5T8Sjq66E6AkjnthCuBCPpz6oex50h5vNLVNNNpa/jGv0na7CADOkQkxyBQKmQ==",
+      "version": "5.28.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-node-hid-noevents/-/hw-transport-node-hid-noevents-5.28.0.tgz",
+      "integrity": "sha512-NPxrY0YLfT9fDL5KXY4jIwKPXjpOOS5XEUDYuvfRQLg7yGeDsn9tJbbkP/8FKOap+oKFXCkgOl9rs0VU2khYqg==",
       "requires": {
-        "@ledgerhq/devices": "^5.23.0",
-        "@ledgerhq/errors": "^5.23.0",
-        "@ledgerhq/hw-transport": "^5.23.0",
-        "@ledgerhq/logs": "^5.23.0",
+        "@ledgerhq/devices": "^5.28.0",
+        "@ledgerhq/errors": "^5.28.0",
+        "@ledgerhq/hw-transport": "^5.28.0",
+        "@ledgerhq/logs": "^5.28.0",
         "node-hid": "1.3.0"
       }
     },
     "@ledgerhq/logs": {
-      "version": "5.23.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-5.23.0.tgz",
-      "integrity": "sha512-88M8RkVHl44k6MAhfrYhx25opnJV24/2XpuTUVklID11f9rBdE+6RZ9OMs39dyX2sDv7TuzIPi5nTRoCqZMDYw=="
+      "version": "5.28.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-5.28.0.tgz",
+      "integrity": "sha512-O+p30yQCJVMHkYRt4mEy2My61JNTyqg9FEs9ZmXXPvXbod85snD6oGaKtDtcvbWCYjiaQt4alD+w/J56hkNBWQ=="
     },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
@@ -506,14 +506,14 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.10.2",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.10.2.tgz",
-          "integrity": "sha512-IzMhbDYCpv26pC2wboJ4MMOa9GKtjplXfcAqrMeNJpUUwpM/2ATt2w1JPUXwS6spu856TvKZL2AOmeU2rAxskw=="
+          "version": "14.14.6",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.6.tgz",
+          "integrity": "sha512-6QlRuqsQ/Ox/aJEQWBEJG7A9+u7oSYl3mem/K8IzxXG/kAGbV1YPD9Bg9Zw3vyxC/YP+zONKwy8hGkSt1jxFMw=="
         },
         "conseiljs": {
-          "version": "5.0.4",
-          "resolved": "https://registry.npmjs.org/conseiljs/-/conseiljs-5.0.4.tgz",
-          "integrity": "sha512-xGCyFfWTdaeAr/DLSlFlDW1ea50G7y/7QEu+lJy+J9eClBDqIrAvnjiUmAVYZU+SS7DexKZm/fqSNU+h8okpCA==",
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/conseiljs/-/conseiljs-5.0.5.tgz",
+          "integrity": "sha512-h2jcsfqtMGl2ymNKjAILfin5GXi4K7i2XOidVAuQ68UnbkQFIcmhpDPcecu1LtBAXJ09+TQaOrsSYGfK8Wc+Xg==",
           "requires": {
             "big-integer": "1.6.48",
             "blakejs": "1.1.0",
@@ -526,9 +526,9 @@
       }
     },
     "@tacoinfra/harbinger-lib": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@tacoinfra/harbinger-lib/-/harbinger-lib-1.6.0.tgz",
-      "integrity": "sha512-C32e+uWeniPx719DjtTzjFfbMY7j2gy7DQpElNz1zBqeBwY1Z2+qy00Rh1QqJ27a6Oe9GRV1gjgZOcII5J5Ilw==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@tacoinfra/harbinger-lib/-/harbinger-lib-1.7.0.tgz",
+      "integrity": "sha512-KENc3NY2bO3Ix63mrb5WMgKu45DI+0KdtsLrz2aJMfzAORHVy+C+QqfpVJs/cgj3Fecv4iqGm+V7xJkHH1omDA==",
       "requires": {
         "@lapo/asn1js": "1.1.0",
         "@ledgerhq/hw-transport": "^5.15.0",
@@ -553,9 +553,9 @@
       },
       "dependencies": {
         "aws-sdk": {
-          "version": "2.753.0",
-          "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.753.0.tgz",
-          "integrity": "sha512-1XjoltWQy76bf+bMA3U1Ta8jSH2jN19UH7vA7J53FT3pCMm24/f7oYtz89VCJflhISs8vB/DdBTHWz2PDRvwEw==",
+          "version": "2.783.0",
+          "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.783.0.tgz",
+          "integrity": "sha512-u3/ZvY/ag1hEkPpgBJxypWRGf8930prIDOWk221pgH0WhlRA9qp3IE8D0j/BKFei0giqlxbN/AB05RITp/XlwQ==",
           "requires": {
             "buffer": "4.9.2",
             "events": "1.1.1",
@@ -591,11 +591,6 @@
             "nearley": "2.19.1"
           }
         },
-        "node-fetch": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
-        },
         "secp256k1": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
@@ -626,14 +621,14 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.10.2",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.10.2.tgz",
-          "integrity": "sha512-IzMhbDYCpv26pC2wboJ4MMOa9GKtjplXfcAqrMeNJpUUwpM/2ATt2w1JPUXwS6spu856TvKZL2AOmeU2rAxskw=="
+          "version": "14.14.6",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.6.tgz",
+          "integrity": "sha512-6QlRuqsQ/Ox/aJEQWBEJG7A9+u7oSYl3mem/K8IzxXG/kAGbV1YPD9Bg9Zw3vyxC/YP+zONKwy8hGkSt1jxFMw=="
         },
         "aws-sdk": {
-          "version": "2.753.0",
-          "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.753.0.tgz",
-          "integrity": "sha512-1XjoltWQy76bf+bMA3U1Ta8jSH2jN19UH7vA7J53FT3pCMm24/f7oYtz89VCJflhISs8vB/DdBTHWz2PDRvwEw==",
+          "version": "2.783.0",
+          "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.783.0.tgz",
+          "integrity": "sha512-u3/ZvY/ag1hEkPpgBJxypWRGf8930prIDOWk221pgH0WhlRA9qp3IE8D0j/BKFei0giqlxbN/AB05RITp/XlwQ==",
           "requires": {
             "buffer": "4.9.2",
             "events": "1.1.1",
@@ -6817,15 +6812,15 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
     },
     "prebuild-install": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.5.tgz",
-      "integrity": "sha512-YmMO7dph9CYKi5IR/BzjOJlRzpxGGVo1EsLSUZ0mt/Mq0HWZIHOKHHcHdT69yG54C9m6i45GpItwRHpk0Py7Uw==",
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.6.tgz",
+      "integrity": "sha512-s8Aai8++QQGi4sSbs/M1Qku62PFK49Jm1CbgXklGz4nmHveDq0wzJkg7Na5QbnO1uNH8K7iqx2EQ/mV0MZEmOg==",
       "requires": {
         "detect-libc": "^1.0.3",
         "expand-template": "^2.0.3",
         "github-from-package": "0.0.0",
         "minimist": "^1.2.3",
-        "mkdirp": "^0.5.1",
+        "mkdirp-classic": "^0.5.3",
         "napi-build-utils": "^1.0.1",
         "node-abi": "^2.7.0",
         "noop-logger": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "Blockscale LLC",
   "license": "MIT",
   "dependencies": {
-    "@tacoinfra/harbinger-lib": "^1.7.0",
+    "@tacoinfra/harbinger-lib": "^1.7.1",
     "@types/aws-lambda": "^8.10.51",
     "@types/aws-sdk": "^2.7.0",
     "@types/secp256k1": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "Blockscale LLC",
   "license": "MIT",
   "dependencies": {
-    "@tacoinfra/harbinger-lib": "^1.6.0",
+    "@tacoinfra/harbinger-lib": "^1.7.0",
     "@types/aws-lambda": "^8.10.51",
     "@types/aws-sdk": "^2.7.0",
     "@types/secp256k1": "^4.0.1",

--- a/serverless.yml
+++ b/serverless.yml
@@ -20,7 +20,7 @@ provider:
 
   # Environment Variables
   environment:
-    AWS_KMS_KEY_ID: ${ssm:${self:custom.awsKmsKeyId}}
+    AWS_KMS_KEY_ID: ${ssm:${self:custom.awsKmsKeyId.${self:provider.stage}}}
     AWS_KMS_KEY_REGION: ${self:custom.awsKmsKeyRegion}
     SIGNER_URL: ${self:custom.signerURL.${self:provider.stage}}
     ORACLE_CONTRACT_ADDRESS: ${self:custom.oracleContractAddress.${self:provider.stage}}
@@ -40,7 +40,11 @@ custom:
     - gemini
     - okex
   # AWS KMS Key ID.
-  awsKmsKeyId: "/tezos/poster-kms-key-id"
+  awsKmsKeyId:
+    coinbase: "/tezos/poster-kms-key-id"
+    binance: "/tezos/binance-poster-kms-key-id"
+    gemini: "/tezos/gemini-poster-kms-key-id"
+    okex: "/tezos/okex-poster-kms-key-id"
   # AWS Region where AWS KMS Key is located.
   awsKmsKeyRegion: "eu-west-1"
   # The address of the Oracle Contract.
@@ -50,16 +54,16 @@ custom:
     gemini: "https://gemini.tzbeta.net/oracle"
     okex: "https://okex.tzbeta.net/oracle"
   oracleContractAddress:
-    coinbase: "KT1P7D7jt3PfjMpsEKPyao1kHQR93t7XR5zh"
-    binance: "KT1XZitEQjpKRUC1k5gpW5qVehiKqB7BfuJn"
-    gemini: "KT1VZprQjiuHG9qz2F7hhiSgzttq9qw6Vvb9"
-    okex: "KT1XnxcyYsPGXb5pCFeykcQvXggTcY1qfX1i"
+    coinbase: "KT1NNfziS5orym8pLvp2qsTjbq2ai9H8sDSr"
+    binance: "KT1F5MSPLiiEmqnePPBUJajPV7zPkU4qWHkZ"
+    gemini: "KT1WmbY7rSG8WufQArssoda99jNhFcHqELB2"
+    okex: "KT1EVxgjWF74AzHpZcKYgfvRoewNATQkWQpE"
   # The address of the Normalizer Contract. If the empty string is provided, updates are not pushed.
   normalizerContractAddress:
-    coinbase: "KT1GcGnKfx8MP3m6axQkkfUiaBM4orYxL5MQ"
-    binance: "KT1QefkWnhqCo4mnMaPBjMr7yy6N7pJbzyBJ"
-    gemini: "KT1N897aHVKtZ2UTbhw6DydZW7aRCUYff4E9"
-    okex: "KT1Wxy2V4zqNu2NCDNJAtc26UNVEdLHjB7V8"
+    coinbase: "KT1LWDzd6mFhjjnb65a1PjHDNZtFKBieTQKH"
+    binance: "KT1Age13nBE2VXxTPjwVJiE8Jbt73kumwxYx"
+    gemini: "KT1VYnz5peWhfPcpBiViBZXa6Z8na3gqdkZS"
+    okex: "KT1NF3n2nPNEa5bd88V4tk1vGWhFfugwuw7K"
   # The address of a node, change to https://rpc.tzbeta.net for mainnet
   nodeAddr: "https://rpctest.tzbeta.net"
   # A Coinbase Pro API Key ID
@@ -79,7 +83,11 @@ custom:
     # These order books are all available on OKEx, feel free to add more
     okex: "BTC-USDT,ETH-USDT,LINK-USDT,XTZ-USDT,ATOM-USDT,CRV-USDT,BAL-USDT,SNX-USDT,KNC-USDT"
   # If set to `TRUE` then zero fee updates will be applied.
-  enableZeroFees: "FALSE"
+  enableZeroFees:
+    coinbase: "FALSE"
+    binance: "FALSE"
+    gemini: "FALSE"
+    okex: "FALSE"
 
 # Functions
 functions:

--- a/serverless.yml
+++ b/serverless.yml
@@ -30,6 +30,7 @@ provider:
     COINBASE_API_KEY_SECRET: ${ssm:${self:custom.coinbaseApiKeySecret}~true}
     COINBASE_API_KEY_PASSPHRASE: ${ssm:${self:custom.coinbaseApiKeyPassphrase}~true}
     ASSETS: ${self:custom.assets.${self:provider.stage}}
+    ENABLE_ZERO_FEES: ${self:custom.enableZeroFees.${self:provider.stage}}
 
 # Custom Variables
 custom:
@@ -77,7 +78,8 @@ custom:
     gemini: "BTC-USD,ETH-USD,LINK-USD,DAI-USD,BAT-USD,OXT-USD,ZEC-USD,BCH-USD,LTC-USD"
     # These order books are all available on OKEx, feel free to add more
     okex: "BTC-USDT,ETH-USDT,LINK-USDT,XTZ-USDT,ATOM-USDT,CRV-USDT,BAL-USDT,SNX-USDT,KNC-USDT"
-
+  # If set to `TRUE` then zero fee updates will be applied.
+  enableZeroFees: "FALSE"
 
 # Functions
 functions:

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ export default async function main(
   apiPassphrase: string,
   assetNames: Array<string>,
   normalizerContractAddress: string | undefined,
+  enableZeroFees: boolean
 ): Promise<string> {
   initOracleLib('debug')
 
@@ -38,6 +39,7 @@ export default async function main(
       signer,
       nodeURL,
       normalizerContractAddress,
+      enableZeroFees
     )
   } else {
     hash = await updateOracleFromFeedOnce(
@@ -49,6 +51,7 @@ export default async function main(
       signer,
       nodeURL,
       normalizerContractAddress,
+      enableZeroFees
     )
   }
 


### PR DESCRIPTION
Allow zero fee updates of Harbinger. 

Specifically:
- Update to `harbinger-lib` v1.7.0, which contains new zero-fee functionality
- Wire new environment variable to check for fees 
- Plumb env var value through in code to `harbinger-lib` calls